### PR TITLE
Use standard context-menu notation and capitalization

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -50,14 +50,14 @@ chrome.commands.onCommand.addListener(function(command) {
 // TODO: Abstract the chrome API stuff into library
 var menuRoot = chrome.contextMenus.create({
   "type": "normal",
-  "title": "New window with..",
+  "title": "New window with...",
   "contexts": ["page"]
 });
 
 var menuWithTabsToRight = chrome.contextMenus.create({
   "type": "normal",
   "parentId": menuRoot,
-  "title": "..tabs to right",
+  "title": "Tabs to the right",
   "contexts": ["page"],
   "onclick": newWindowWithTabsToRight
 });
@@ -65,7 +65,7 @@ var menuWithTabsToRight = chrome.contextMenus.create({
 var menuWithThisTabAndTabsToRight = chrome.contextMenus.create({
   "type": "normal",
   "parentId": menuRoot,
-  "title": "..this tab and tabs to right",
+  "title": "This tab and tabs to the right",
   "contexts": ["page"],
   "onclick": newWindowWithCurrentAndTabsToRight
 });


### PR DESCRIPTION
Hi there, some years ago I was about to develop and publish an extension myself with this very same functionality. However I found yours and that's what I've been using.

However since the first day I was quite unhappy with the inconsistency of the context-menu notation and capitalization between this extension and the rest of the software I use.

It took me some time to make this step but here's the PR that fixes it in case you can accept it and publish a new version to the Chrome Web Store. Otherwise no worries :)